### PR TITLE
link from account name to first role console

### DIFF
--- a/templates/accountEntry.html
+++ b/templates/accountEntry.html
@@ -3,7 +3,7 @@
     <a class="favorite" ng-class="{'favorite-on': account.favorite}" href="#" ng-click="addFavorite(account)"></a>
     <a class="costs" ng-show="costsLink" href="{{costsLink}}{{account.AccountName}}" target="_blank"></a>
   </div>
-  <h4>{{account.AccountName}}</h4>
+  <h4><a href="#/console/{{account.Roles[0].URLSuffix}}">{{account.AccountName}}</a></h4>
   <table>
     <tr ng-repeat="role in account.Roles | orderBy:'Name'" class="row">
       <td>


### PR DESCRIPTION
This is great for things like vimperator since it's possible to do
something like `click the link my-account` to log in without the mouse.
Without this I have to do something like `click on the 27th AWSConsole
link`...

The link will point to the first role name (I don't know if this should
be made more clever eG always link to the full-access role or
equivalent).
But just using the first role feels right. In our production AFP we have
exactly 2 accounts with 2 roles, everything else just has one role.

Neither the JS search feature (requires me to click) nor the star feature (requires me to keep cookies) are useful to me in this regard.
